### PR TITLE
Limit scoreboard lengths

### DIFF
--- a/common/src/main/java/io/github/bedwarsrel/game/Game.java
+++ b/common/src/main/java/io/github/bedwarsrel/game/Game.java
@@ -58,6 +58,9 @@ import org.bukkit.util.Vector;
 @Data
 public class Game {
 
+  private static final int MAX_OBJECTIVE_DISPLAY_LENGTH = 32;
+  private static final int MAX_SCORE_LENGTH = 40;
+
   private boolean autobalance = false;
   private String builder = null;
   private YamlConfiguration config = null;
@@ -486,7 +489,10 @@ public class Game {
     finalStr = finalStr.replace("$players$", String.valueOf(this.getPlayerAmount()));
     finalStr = finalStr.replace("$maxplayers$", String.valueOf(this.getMaxPlayers()));
 
-    return ChatColor.translateAlternateColorCodes('&', finalStr);
+    finalStr = ChatColor.translateAlternateColorCodes('&', finalStr);
+    //this is used for display name of the object and score name
+    //the display name is only smaller so choose this limit
+    return limitScoreboardLength(finalStr, MAX_OBJECTIVE_DISPLAY_LENGTH);
   }
 
   private String formatScoreboardTeam(Team team, boolean destroyed) {
@@ -508,7 +514,8 @@ public class Game {
     format = format.replace("$status$", (destroyed) ? Game.bedLostString() : Game.bedExistString());
     format = format.replace("$team$", team.getChatColor() + team.getName());
 
-    return ChatColor.translateAlternateColorCodes('&', format);
+    format = ChatColor.translateAlternateColorCodes('&', format);
+    return limitScoreboardLength(format, MAX_SCORE_LENGTH);
   }
 
   private String formatScoreboardTitle() {
@@ -521,7 +528,16 @@ public class Game {
     format = format.replace("$game$", this.name);
     format = format.replace("$time$", this.getFormattedTimeLeft());
 
-    return ChatColor.translateAlternateColorCodes('&', format);
+    format = ChatColor.translateAlternateColorCodes('&', format);
+    return limitScoreboardLength(format, MAX_OBJECTIVE_DISPLAY_LENGTH);
+  }
+
+  private String limitScoreboardLength(String fullText, int maxLength) {
+    if (fullText.length() > maxLength) {
+      return fullText.substring(0, maxLength);
+    }
+
+    return fullText;
   }
 
   public int getCurrentPlayerAmount() {


### PR DESCRIPTION
Just a minor change to limit the scoreboard length. If the length is higher than the maximum supported length it automatically reduces it. This fixes:

```log
Caused by: java.lang.IllegalArgumentException: Entry cannot be longer than 40 characters!
at org.bukkit.craftbukkit.v1_8_R3.scoreboard.CraftObjective.getScore(CraftObjective.java:96) ~[spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
at io.github.bedwarsrel.game.Game.updateLobbyScoreboard(Game.java:1943) ~[?:?]
```