### PR TITLE
Use material constant instead of id for item of bow category in shop.yml

### DIFF
--- a/common/src/main/resources/shop.yml
+++ b/common/src/main/resources/shop.yml
@@ -161,7 +161,7 @@ shop:
             DURABILITY: 1
             KNOCKBACK: 1
   bows:
-    item: 261
+    item: BOW
     name: "Bows"
     order: 30
     permission: bw.base


### PR DESCRIPTION
BedwarsRel parses all materials by name and parsing a material by id is deprecated in the bukkit api.
We should change the default in the config and the shop file to material name / constant instead of using the id.